### PR TITLE
탭 활성화 표시 초기 애니메이션 제거

### DIFF
--- a/app/src/main/java/com/pluu/webtoon/ui/weekly/MainFragment.kt
+++ b/app/src/main/java/com/pluu/webtoon/ui/weekly/MainFragment.kt
@@ -59,7 +59,7 @@ class MainFragment : Fragment(R.layout.fragment_toon) {
                 lifecycle = viewLifecycleOwner.lifecycle
             )
             // 금일 기준으로 ViewPager 기본 표시
-            currentItem = serviceApi.todayTabPosition
+            setCurrentItem(serviceApi.todayTabPosition, false)
         }
 
         TabLayoutMediator(binding.slidingTabLayout, binding.viewPager) { tab, position ->


### PR DESCRIPTION
다른 웹툰을 선택할 때마다 활성화 탭 표시가 현재 요일과 상관 없이 계속 어중간한 곳에서 애니메이션을 시작하길래 `smoothScroll`을 `false`으로 설정했습니다.

**변경 전**

![이후](https://user-images.githubusercontent.com/33057457/96397596-a9f6b000-117e-11eb-83eb-6a0ca16bf13d.gif)

**변경 후**

![이후](https://user-images.githubusercontent.com/33057457/96397581-a6632900-117e-11eb-965d-4b795e25e432.gif)
