### PR TITLE
즐겨찾기 변동 시 목록 재정렬

### DIFF
--- a/features/ui-weekly/src/main/java/com/pluu/webtoon/weekly/ui/WebtoonListFragment.kt
+++ b/features/ui-weekly/src/main/java/com/pluu/webtoon/weekly/ui/WebtoonListFragment.kt
@@ -90,6 +90,7 @@ class WebtoonListFragment : Fragment(R.layout.fragment_webtoon_list) {
         }
         toonViewModel.updateEvent.observeNonNull(viewLifecycleOwner) {
             favoriteUpdate(it)
+            viewModel.onSortList()
         }
     }
 

--- a/features/ui-weekly/src/main/java/com/pluu/webtoon/weekly/ui/WeekyViewModel.kt
+++ b/features/ui-weekly/src/main/java/com/pluu/webtoon/weekly/ui/WeekyViewModel.kt
@@ -61,6 +61,28 @@ class WeekyViewModel @ViewModelInject constructor(
             emptyList()
         }
     }
+
+    fun onSortList() {
+        viewModelScope.launch {
+            _listEvent.value = sortedListEvent()
+        }
+    }
+
+    private suspend fun sortedListEvent(): List<ToonInfo> = withContext(dispatchers.computation) {
+        val list = listEvent.value
+        if (!list.isNullOrEmpty()) {
+            list
+                .sortedWith(compareBy<ToonInfo> {
+                    !it.isFavorite
+                }.thenBy {
+                    it.title
+                })
+                .toList()
+        } else {
+            emptyList()
+        }
+    }
+
 }
 
 sealed class WeeklyEvent {


### PR DESCRIPTION
즐겨찾기를 설정하거나 제거하고 다시 목록에 오면 표시만 추가되고 정렬이 그대로라서 재정렬하도록 추가했습니다.

그런데 막상 변경해보니까 의도된 동작 같기도 해서 ;ㅅ; 지도편달 부탁드립니다.

**변경 전**

![sort-before](https://user-images.githubusercontent.com/33057457/96401886-6fdedb80-1189-11eb-80aa-d02a010401fd.gif)

**변경 후**

![sort-after](https://user-images.githubusercontent.com/33057457/96401880-6b1a2780-1189-11eb-8254-4e92800886f3.gif)
