### PR TITLE
Enable gradle-home-cache-cleanup

### DIFF
--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -28,6 +28,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: current
+          gradle-home-cache-cleanup: true
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
https://github.com/gradle/gradle-build-action#removing-unused-files-from-gradle-user-home-before-saving-to-cache

> **[캐시에 저장하기 전에 Gradle 사용자 홈에서 사용하지 않는 파일 제거]**
> 
> Gradle 사용자 홈 디렉토리는 시간이 지남에 따라 증가하는 경향이 있습니다. 새 Gradle 래퍼 버전으로 전환하거나 종속성 버전을 업그레이드하면 이전 파일이 자동으로 즉시 제거되지 않습니다. 이는 로컬 환경에서 의미가 있을 수 있지만 GitHub Actions 환경에서는 훨씬 더 큰 Gradle 사용자 홈 캐시 항목이 저장 및 복원될 수 있습니다.
> 
> 이러한 상황을 피하기 위해 gradle-build-action은 `gradle-home-cache-cleanup` 매개변수를 지원합니다. 활성화되면 이 기능은 Gradle 사용자 홈을 GitHub 작업 캐시에 저장하기 전에 GitHub 작업 워크플로 동안 Gradle에서 사용하지 않은 모든 파일을 Gradle 사용자 홈에서 삭제하려고 시도합니다.
> 
> Gradle 홈 캐시 정리는 기본적으로 비활성화되어 있습니다.